### PR TITLE
Update google-analyticator.php

### DIFF
--- a/google-analyticator.php
+++ b/google-analyticator.php
@@ -1286,7 +1286,7 @@ function ga_current_user_is($roles)
 	if ( !$roles ) return false;
 
 	global $current_user;
-	get_currentuserinfo();
+	wp_get_current_user();
 	$user_id = intval( $current_user->ID );
 
 	if ( !$user_id ) {


### PR DESCRIPTION
get_currentuserinfo got deprecated in WP 4.5 and now its called wp_get_current_user
